### PR TITLE
access_globals issue

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -353,18 +353,18 @@ let scriptUrl = 'https://app.usercentrics.eu/browser-ui/latest/loader.js';
 
 setInWindow('settingsId', settingsId);
 
-if (defaultLanguage !== 'auto' && queryPermission('access_globals', 'language'))
+if (defaultLanguage !== 'auto' && queryPermission('access_globals', 'readwrite', 'language'))
 {
   setInWindow('language', defaultLanguage);
 }
 
 
-if (isTcfEnabled && queryPermission('access_globals', 'tcfEnabled'))
+if (isTcfEnabled && queryPermission('access_globals', 'readwrite', 'tcfEnabled'))
 {
   setInWindow('tcfEnabled', true);
 }
 
-if (isAmpEnabled && queryPermission('access_globals', 'ampEnabled'))
+if (isAmpEnabled && queryPermission('access_globals', 'readwrite', 'ampEnabled'))
 {
   setInWindow('ampEnabled', true);
 }


### PR DESCRIPTION
Hello guys. Based on [Google documentation](https://developers.google.com/tag-platform/tag-manager/templates/permissions#access_globals), when you pass the access_globals parameter into queryPermission API, you should specify the permission level (read, write, readwrite, execute) as well. Otherwise, you always have a false return.